### PR TITLE
Fix prefix does not work on handling queue transaction

### DIFF
--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -99,9 +99,9 @@ class NewRelicTransactionHandler
             app(NewRelicTransaction::class)
                 ->start(
                     config('new-relic.queue.prefix') .
-                    (method_exists($event->job, 'resolveName'))
+                    ((method_exists($event->job, 'resolveName'))
                         ? $event->job->resolveName()
-                        : $event->job->getName()
+                        : $event->job->getName())
                 )->addParameter('queue', $event->job->getQueue())
                 ->addParameter('connection', $event->connectionName);
         });


### PR DESCRIPTION
The prefix in queue transaction does not work, adding parentheses so the prefix is concatenated to a job in the right order.