### PR TITLE
Fix #15 missing fallback for the empty event name.

### DIFF
--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -250,7 +250,7 @@ class NewRelicTransactionHandler
                 app(NewRelicTransaction::class)->start(
                     config('new-relic.scheduler.prefix') .
                     ($scheduledTaskStarting->task->description ?: $this->parseTaskCommand(
-                        $scheduledTaskStarting->task->command
+                        $scheduledTaskStarting->task->command ?? 'unknown'
                     ))
                 )->addParameter(
                     'command',


### PR DESCRIPTION
The event name can be null in Laravel.

See the ticket description