### PR TITLE
Fix empty job names causing 'OtherTransaction/php/artisan' in New Relic

### DIFF
--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -173,16 +173,6 @@ class NewRelicTransactionHandler
     /**
      * Resolve the job name for New Relic transaction naming.
      *
-     * Uses a cascading approach to find the best name, prioritizing backward compatibility:
-     * 1. resolveName() - Laravel's standard display name method, honors custom displayName()
-     *    and provides better names for closures/mailables
-     * 2. getName() - raw job name from payload
-     * 3. resolveQueuedJobClass() - safety net when displayName is empty (fixes the bug)
-     * 4. 'Unknown Job [queue-name]' - final fallback to prevent empty transaction names
-     *
-     * This order preserves backward compatibility by respecting Laravel's intended design
-     * where displayName() is the primary source, while still fixing the empty name bug.
-     *
      * @param \Illuminate\Contracts\Queue\Job $job
      * @return string
      */

--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -182,7 +182,7 @@ class NewRelicTransactionHandler
      * @param \Illuminate\Contracts\Queue\Job $job
      * @return string
      */
-    private function resolveJobName(Job $job): string
+    protected function resolveJobName(Job $job): string
     {
         $jobName = '';
 

--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -122,12 +122,8 @@ class NewRelicTransactionHandler
 
                 // Start a new transaction for this job
                 app(NewRelicTransaction::class)
-                    ->start(
-                        config('new-relic.queue.prefix') .
-                        ((method_exists($jobProcessing->job, 'resolveName'))
-                            ? $jobProcessing->job->resolveName()
-                            : $jobProcessing->job->getName())
-                    )->addParameter('queue', $jobProcessing->job->getQueue())
+                    ->start(config('new-relic.queue.prefix') . $this->resolveJobName($jobProcessing->job))
+                    ->addParameter('queue', $jobProcessing->job->getQueue())
                     ->addParameter(
                         'connection',
                         $jobProcessing->connectionName
@@ -172,6 +168,45 @@ class NewRelicTransactionHandler
             config('new-relic.queue.ignore.jobs'),
             $job::class
         );
+    }
+
+    /**
+     * Resolve the job name for New Relic transaction naming.
+     *
+     * Uses a cascading approach to get the most accurate job name:
+     * 1. resolveQueuedJobClass() - gets actual class from payload['data']['commandName']
+     * 2. resolveName() - gets displayName or falls back to payload['job']
+     * 3. getName() - falls back to payload['job']
+     * 4. 'Unknown Job [queue-name]' - final fallback to prevent empty transaction names
+     *
+     * @param \Illuminate\Contracts\Queue\Job $job
+     * @return string
+     */
+    private function resolveJobName(Job $job): string
+    {
+        $jobName = '';
+
+        // Try to get the actual job class from the payload
+        if (method_exists($job, 'resolveQueuedJobClass')) {
+            $jobName = $job->resolveQueuedJobClass();
+        }
+
+        // Fall back to the display name or job handler
+        if (empty($jobName) && method_exists($job, 'resolveName')) {
+            $jobName = $job->resolveName();
+        }
+
+        // Fall back to the raw job name from payload
+        if (empty($jobName)) {
+            $jobName = $job->getName();
+        }
+
+        // Final fallback to prevent empty transaction names in New Relic
+        if (empty($jobName)) {
+            $jobName = 'Unknown Job [' . $job->getQueue() . ']';
+        }
+
+        return $jobName;
     }
 
     /**

--- a/src/NewRelicTransactionHandler.php
+++ b/src/NewRelicTransactionHandler.php
@@ -173,11 +173,15 @@ class NewRelicTransactionHandler
     /**
      * Resolve the job name for New Relic transaction naming.
      *
-     * Uses a cascading approach to get the most accurate job name:
-     * 1. resolveQueuedJobClass() - gets actual class from payload['data']['commandName']
-     * 2. resolveName() - gets displayName or falls back to payload['job']
-     * 3. getName() - falls back to payload['job']
+     * Uses a cascading approach to find the best name, prioritizing backward compatibility:
+     * 1. resolveName() - Laravel's standard display name method, honors custom displayName()
+     *    and provides better names for closures/mailables
+     * 2. getName() - raw job name from payload
+     * 3. resolveQueuedJobClass() - safety net when displayName is empty (fixes the bug)
      * 4. 'Unknown Job [queue-name]' - final fallback to prevent empty transaction names
+     *
+     * This order preserves backward compatibility by respecting Laravel's intended design
+     * where displayName() is the primary source, while still fixing the empty name bug.
      *
      * @param \Illuminate\Contracts\Queue\Job $job
      * @return string
@@ -186,19 +190,19 @@ class NewRelicTransactionHandler
     {
         $jobName = '';
 
-        // Try to get the actual job class from the payload
-        if (method_exists($job, 'resolveQueuedJobClass')) {
-            $jobName = $job->resolveQueuedJobClass();
-        }
-
-        // Fall back to the display name or job handler
-        if (empty($jobName) && method_exists($job, 'resolveName')) {
+        // Primary: Use Laravel's standard display name (honors custom displayName)
+        if (method_exists($job, 'resolveName')) {
             $jobName = $job->resolveName();
         }
 
-        // Fall back to the raw job name from payload
+        // Secondary: Fall back to the raw job name from payload
         if (empty($jobName)) {
             $jobName = $job->getName();
+        }
+
+        // Tertiary: Use the actual job class from payload as safety net for empty displayName
+        if (empty($jobName) && method_exists($job, 'resolveQueuedJobClass')) {
+            $jobName = $job->resolveQueuedJobClass();
         }
 
         // Final fallback to prevent empty transaction names in New Relic

--- a/tests/ResolveJobNameTest.php
+++ b/tests/ResolveJobNameTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Queue\Job;
+use JackWH\LaravelNewRelic\NewRelicTransactionHandler;
+
+/**
+ * Test the job name resolution logic that prevents empty transaction names
+ * from appearing as "OtherTransaction/php/artisan" in New Relic.
+ */
+
+/**
+ * Create a test handler that exposes the protected resolveJobName method.
+ */
+function createTestHandler(): object
+{
+    return new class extends NewRelicTransactionHandler {
+        public function testResolveJobName(Job $job): string
+        {
+            return $this->resolveJobName($job);
+        }
+    };
+}
+
+/**
+ * Base job stub with all required Job interface methods implemented.
+ */
+abstract class BaseJobStub implements Job
+{
+    public function getJobId(): string|int|null
+    {
+        return '123';
+    }
+
+    public function getRawBody(): string
+    {
+        return '{}';
+    }
+
+    public function uuid(): ?string
+    {
+        return null;
+    }
+
+    public function fire(): void {}
+
+    public function delete(): void {}
+
+    public function isDeleted(): bool
+    {
+        return false;
+    }
+
+    public function release($delay = 0): void {}
+
+    public function isReleased(): bool
+    {
+        return false;
+    }
+
+    public function isDeletedOrReleased(): bool
+    {
+        return false;
+    }
+
+    public function hasFailed(): bool
+    {
+        return false;
+    }
+
+    public function markAsFailed(): void {}
+
+    public function fail($e = null): void {}
+
+    public function maxTries(): ?int
+    {
+        return null;
+    }
+
+    public function maxExceptions(): ?int
+    {
+        return null;
+    }
+
+    public function shouldFailOnTimeout(): bool
+    {
+        return false;
+    }
+
+    public function backoff(): int|array|null
+    {
+        return null;
+    }
+
+    public function timeout(): ?int
+    {
+        return null;
+    }
+
+    public function retryUntil(): ?int
+    {
+        return null;
+    }
+
+    public function getConnectionName(): string
+    {
+        return 'database';
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public function attempts(): int
+    {
+        return 1;
+    }
+}
+
+it('resolves job name from resolveQueuedJobClass when available', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return 'App\Jobs\ProcessPayment';
+        }
+
+        public function resolveName(): string
+        {
+            return 'Should Not Be Called';
+        }
+
+        public function getName(): string
+        {
+            return 'Should Not Be Called';
+        }
+
+        public function getQueue(): string
+        {
+            return 'default';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('App\Jobs\ProcessPayment');
+});
+
+it('falls back to resolveName when resolveQueuedJobClass returns empty', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return '';
+        }
+
+        public function resolveName(): string
+        {
+            return 'App\Jobs\SendEmail';
+        }
+
+        public function getName(): string
+        {
+            return 'Should Not Be Called';
+        }
+
+        public function getQueue(): string
+        {
+            return 'emails';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('App\Jobs\SendEmail');
+});
+
+it('falls back to getName when both resolveQueuedJobClass and resolveName return empty', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return '';
+        }
+
+        public function resolveName(): string
+        {
+            return '';
+        }
+
+        public function getName(): string
+        {
+            return 'SomeStringBasedJob';
+        }
+
+        public function getQueue(): string
+        {
+            return 'low-priority';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('SomeStringBasedJob');
+});
+
+it('returns Unknown Job with queue name when all resolution methods return empty', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return '';
+        }
+
+        public function resolveName(): string
+        {
+            return '';
+        }
+
+        public function getName(): string
+        {
+            return '';
+        }
+
+        public function getQueue(): string
+        {
+            return 'default';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('Unknown Job [default]');
+});
+
+it('handles job without resolveQueuedJobClass method', function (): void {
+    $handler = createTestHandler();
+
+    // Job stub that intentionally does NOT have resolveQueuedJobClass method
+    $job = new class extends BaseJobStub {
+        public function resolveName(): string
+        {
+            return 'CustomJobName';
+        }
+
+        public function getName(): string
+        {
+            return 'Illuminate\Queue\CallQueuedHandler@call';
+        }
+
+        public function getQueue(): string
+        {
+            return 'default';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('CustomJobName');
+});
+
+it('prioritizes resolveQueuedJobClass over resolveName', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return 'App\Jobs\ActualJobClass';
+        }
+
+        public function resolveName(): string
+        {
+            throw new \RuntimeException('resolveName should not be called when resolveQueuedJobClass returns a value');
+        }
+
+        public function getName(): string
+        {
+            throw new \RuntimeException('getName should not be called when resolveQueuedJobClass returns a value');
+        }
+
+        public function getQueue(): string
+        {
+            return 'default';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('App\Jobs\ActualJobClass');
+});
+
+it('handles different queue names in fallback', function (): void {
+    $handler = createTestHandler();
+
+    $job = new class extends BaseJobStub {
+        public function resolveQueuedJobClass(): string
+        {
+            return '';
+        }
+
+        public function resolveName(): string
+        {
+            return '';
+        }
+
+        public function getName(): string
+        {
+            return '';
+        }
+
+        public function getQueue(): string
+        {
+            return 'high-priority-tasks';
+        }
+    };
+
+    expect($handler->testResolveJobName($job))->toBe('Unknown Job [high-priority-tasks]');
+});

--- a/tests/ResolveJobNameTest.php
+++ b/tests/ResolveJobNameTest.php
@@ -119,21 +119,21 @@ abstract class BaseJobStub implements Job
     }
 }
 
-it('resolves job name from resolveQueuedJobClass when available', function (): void {
+it('resolves job name from resolveName when available', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
+        public function resolveName(): string
         {
             return 'App\Jobs\ProcessPayment';
         }
 
-        public function resolveName(): string
+        public function getName(): string
         {
             return 'Should Not Be Called';
         }
 
-        public function getName(): string
+        public function resolveQueuedJobClass(): string
         {
             return 'Should Not Be Called';
         }
@@ -147,21 +147,21 @@ it('resolves job name from resolveQueuedJobClass when available', function (): v
     expect($handler->testResolveJobName($job))->toBe('App\Jobs\ProcessPayment');
 });
 
-it('falls back to resolveName when resolveQueuedJobClass returns empty', function (): void {
+it('falls back to getName when resolveName returns empty', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
+        public function resolveName(): string
         {
             return '';
         }
 
-        public function resolveName(): string
+        public function getName(): string
         {
             return 'App\Jobs\SendEmail';
         }
 
-        public function getName(): string
+        public function resolveQueuedJobClass(): string
         {
             return 'Should Not Be Called';
         }
@@ -175,15 +175,10 @@ it('falls back to resolveName when resolveQueuedJobClass returns empty', functio
     expect($handler->testResolveJobName($job))->toBe('App\Jobs\SendEmail');
 });
 
-it('falls back to getName when both resolveQueuedJobClass and resolveName return empty', function (): void {
+it('falls back to resolveQueuedJobClass when both resolveName and getName return empty', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
-        {
-            return '';
-        }
-
         public function resolveName(): string
         {
             return '';
@@ -191,7 +186,12 @@ it('falls back to getName when both resolveQueuedJobClass and resolveName return
 
         public function getName(): string
         {
-            return 'SomeStringBasedJob';
+            return '';
+        }
+
+        public function resolveQueuedJobClass(): string
+        {
+            return 'App\Jobs\ExtractedFromPayload';
         }
 
         public function getQueue(): string
@@ -200,24 +200,24 @@ it('falls back to getName when both resolveQueuedJobClass and resolveName return
         }
     };
 
-    expect($handler->testResolveJobName($job))->toBe('SomeStringBasedJob');
+    expect($handler->testResolveJobName($job))->toBe('App\Jobs\ExtractedFromPayload');
 });
 
 it('returns Unknown Job with queue name when all resolution methods return empty', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
-        {
-            return '';
-        }
-
         public function resolveName(): string
         {
             return '';
         }
 
         public function getName(): string
+        {
+            return '';
+        }
+
+        public function resolveQueuedJobClass(): string
         {
             return '';
         }
@@ -255,23 +255,23 @@ it('handles job without resolveQueuedJobClass method', function (): void {
     expect($handler->testResolveJobName($job))->toBe('CustomJobName');
 });
 
-it('prioritizes resolveQueuedJobClass over resolveName', function (): void {
+it('prioritizes resolveName over getName and resolveQueuedJobClass', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
-        {
-            return 'App\Jobs\ActualJobClass';
-        }
-
         public function resolveName(): string
         {
-            throw new \RuntimeException('resolveName should not be called when resolveQueuedJobClass returns a value');
+            return 'App\Jobs\CustomDisplayName';
         }
 
         public function getName(): string
         {
-            throw new \RuntimeException('getName should not be called when resolveQueuedJobClass returns a value');
+            throw new \RuntimeException('getName should not be called when resolveName returns a value');
+        }
+
+        public function resolveQueuedJobClass(): string
+        {
+            throw new \RuntimeException('resolveQueuedJobClass should not be called when resolveName returns a value');
         }
 
         public function getQueue(): string
@@ -280,24 +280,24 @@ it('prioritizes resolveQueuedJobClass over resolveName', function (): void {
         }
     };
 
-    expect($handler->testResolveJobName($job))->toBe('App\Jobs\ActualJobClass');
+    expect($handler->testResolveJobName($job))->toBe('App\Jobs\CustomDisplayName');
 });
 
 it('handles different queue names in fallback', function (): void {
     $handler = createTestHandler();
 
     $job = new class extends BaseJobStub {
-        public function resolveQueuedJobClass(): string
-        {
-            return '';
-        }
-
         public function resolveName(): string
         {
             return '';
         }
 
         public function getName(): string
+        {
+            return '';
+        }
+
+        public function resolveQueuedJobClass(): string
         {
             return '';
         }


### PR DESCRIPTION
## Problem

Queue jobs are being tracked in New Relic with the generic transaction name `artisan` (or fullname:`OtherTransaction/php/artisan`) instead of their actual job class names (e.g., `App\Jobs\ProcessPayment`). This results in:

- plenty of transactions appearing with meaningless names in New Relic APM
- Inability to properly monitor and track individual job performance
- Difficulty identifying which specific jobs are causing performance issues
- False positives from monitoring alerts for slow background tasks

### Why This Happens

The issue occurs when `NewRelicTransactionHandler` receives a queue job with an empty name from Laravel's job name resolution. When `newrelic_name_transaction('')` is called with an empty string, New Relic ignores it and defaults to the generic "OtherTransaction/php/artisan" name.

**Root Cause:** The original implementation only used `$job->resolveName()`, which can return an empty string in several scenarios:

1. **String-based jobs** with malformed `displayName` in the payload
2. **Serialization failures** during Redis queue storage
3. **Legacy jobs** queued before Laravel added the `displayName` field
4. **Edge cases** where `JobName::resolve()` falls through without finding a name

Laravel's `$job->resolveName()` uses `JobName::resolve()` method that only checks `payload['displayName']`:

```php
public static function resolve($name, $payload)
{
    if (! empty($payload['displayName'])) {
        return $payload['displayName'];
    }
    
    return $name;  // Can be wrapper class or empty
}
```

If `displayName` is missing or empty, and `$name` is a wrapper class like `Illuminate\Queue\CallQueuedHandler@call`, the resolution fails to extract the actual job class name.

## Solution

This PR implements a **cascading job name resolution strategy** with four levels of fallback, designed to maximize backward compatibility while fixing the empty name bug:

### 1. `resolveName()` (Primary)
Laravel's standard job display name method. This respects:
- Custom `displayName()` methods that applications may override
- Better names for closures: `"Closure (routes/web.php:15)"` instead of generic class names
- Better names for mailables: `"OrderShipped"` instead of `"Illuminate\Mail\SendQueuedMailable"`
- Existing application behavior (backward compatible)

### 2. `getName()` (Secondary)
Returns the raw `payload['job']` value when `displayName` is not available.

### 3. `resolveQueuedJobClass()` (Tertiary - The Bug Fix)
Gets the actual job class from `payload['data']['commandName']`, which Laravel **always sets** for object-based jobs. This is the safety net that prevents empty transaction names:

```php
// From Laravel's Queue.php
protected function createObjectPayload($job, $queue)
{
    return [
        'data' => [
            'commandName' => get_class($job),  // Always present!
        ],
    ];
}
```

**Key insight:** This method is placed third (not first) to preserve backward compatibility. It only activates when both `displayName` and raw job name are empty, which is exactly when the bug occurs.

### 4. `'Unknown Job [queue-name]'` (Final Fallback)
Prevents empty transaction names in any edge case by providing a descriptive fallback that includes the queue name for debugging.

## Breaking Changes

None. This is a backward-compatible enhancement that only affects internal job name resolution logic. The cascading approach ensures existing applications see no change in behavior while fixing the empty name bug for edge cases.